### PR TITLE
client id as advanced parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/)
 
+## [Unreleased]
+
+### Added
+
+- `Client_Id` parameter has been added to the advanced section of Kafka Consumer.
+- When the `Client_Id` field is empty, the plugin defaults to `DNS:TASK ID`.
+
+### Changed
+
+- The string `CMEM_BASE_URI` has been made constant. As a result, updated `@needs-cmem`.
+
 ## [1.1.0] 2022-10-21
 
 ### Added

--- a/cmem_plugin_kafka/constants.py
+++ b/cmem_plugin_kafka/constants.py
@@ -2,6 +2,7 @@
 import collections
 
 KAFKA_TIMEOUT = 5
+BASE_URI = 'CMEM_BASE_URI'
 
 # Security Protocols
 SECURITY_PROTOCOLS = collections.OrderedDict(

--- a/cmem_plugin_kafka/utils.py
+++ b/cmem_plugin_kafka/utils.py
@@ -4,6 +4,8 @@ import re
 from typing import Dict, Any, Iterator
 from xml.sax.handler import ContentHandler  # nosec B406
 from xml.sax.saxutils import escape  # nosec B406
+from urllib.parse import urlparse
+import os
 
 from cmem.cmempy.workspace.projects.resources.resource import get_resource_response
 from cmem.cmempy.workspace.tasks import get_task
@@ -20,7 +22,7 @@ from cmem_plugin_base.dataintegration.utils import (
 from confluent_kafka import Producer, Consumer, KafkaError
 from confluent_kafka.admin import AdminClient, TopicMetadata, ClusterMetadata
 
-from .constants import KAFKA_TIMEOUT
+from .constants import KAFKA_TIMEOUT, BASE_URI
 
 
 # pylint: disable-msg=too-few-public-methods
@@ -245,6 +247,15 @@ class KafkaMessageHandler(ContentHandler):
                 operation_desc="messages sent",
             )
         )
+
+
+def get_client_id(client_id: str, task_id: str):
+    """return dns:taskid when client id is empty"""
+    base_url = os.environ[BASE_URI]
+    if len(client_id) == 0 < len(task_id) <= len(base_url):
+        dns = urlparse(base_url).netloc
+        return f'{dns}:{task_id}'
+    return client_id
 
 
 def validate_kafka_config(config: Dict[str, Any], topic: str, log: PluginLogger):

--- a/cmem_plugin_kafka/workflow/consumer.py
+++ b/cmem_plugin_kafka/workflow/consumer.py
@@ -50,7 +50,7 @@ The sole purpose of this is to be able to track the source of requests beyond ju
 ip and port by allowing a logical application name to be included in Kafka logs
 and monitoring aggregates.
 
-On empty Client Id, Plugin uses DNS:TASK_ID as Client Id as default.
+When the Client Id field is empty, the plugin defaults to DNS:TASK ID.
 """
 
 

--- a/cmem_plugin_kafka/workflow/consumer.py
+++ b/cmem_plugin_kafka/workflow/consumer.py
@@ -41,6 +41,17 @@ not exist any more on the server (e.g. because that data has been deleted).
 - `latest` will receive nothing but will get any new records on the next run.
 """
 
+CLIENT_ID_DESCRIPTION = """
+An optional identifier of a Kafka consumer (in a consumer group) that is passed
+to a Kafka broker with every request.
+
+The sole purpose of this is to be able to track the source of requests beyond just
+ip and port by allowing a logical application name to be included in Kafka logs
+and monitoring aggregates.
+
+On empty Client Id, Plugin uses DNS:TASK_ID as Client Id as default.
+"""
+
 
 @Plugin(
     label="Kafka Consumer (Receive Messages)",
@@ -127,6 +138,13 @@ look this.
             description=AUTO_OFFSET_RESET_DESCRIPTION,
         ),
         PluginParameter(
+            name="client_id",
+            label="Client Id",
+            advanced=True,
+            default_value="",
+            description=CLIENT_ID_DESCRIPTION,
+        ),
+        PluginParameter(
             name="message_dataset",
             label="Messages Dataset",
             description="Where do you want to save the messages?"
@@ -143,16 +161,17 @@ class KafkaConsumerPlugin(WorkflowPlugin):
 
     # pylint: disable=too-many-instance-attributes
     def __init__(
-        self,
-        message_dataset: str,
-        bootstrap_servers: str,
-        security_protocol: str,
-        sasl_mechanisms: str,
-        sasl_username: str,
-        sasl_password: str,
-        kafka_topic: str,
-        group_id: str,
-        auto_offset_reset: str,
+            self,
+            message_dataset: str,
+            bootstrap_servers: str,
+            security_protocol: str,
+            sasl_mechanisms: str,
+            sasl_username: str,
+            sasl_password: str,
+            kafka_topic: str,
+            group_id: str,
+            auto_offset_reset: str,
+            client_id: str,
     ) -> None:
         if not isinstance(bootstrap_servers, str):
             raise ValueError("Specified server id is invalid")
@@ -165,6 +184,7 @@ class KafkaConsumerPlugin(WorkflowPlugin):
         self.kafka_topic = kafka_topic
         self.group_id = group_id
         self.auto_offset_reset = auto_offset_reset
+        self.client_id = client_id
         validate_kafka_config(self.get_config(), self.kafka_topic, self.log)
         self._kafka_stats: dict = {}
 

--- a/cmem_plugin_kafka/workflow/consumer.py
+++ b/cmem_plugin_kafka/workflow/consumer.py
@@ -22,6 +22,7 @@ from cmem_plugin_kafka.utils import (
     KafkaConsumer,
     validate_kafka_config,
     get_kafka_statistics,
+    get_client_id,
 )
 
 CONSUMER_GROUP_DESCRIPTION = """
@@ -194,7 +195,7 @@ class KafkaConsumerPlugin(WorkflowPlugin):
         for key, value in self._kafka_stats.items():
             self.log.info(f"kafka-stats: {key:10} - {value:10}")
 
-    def get_config(self) -> Dict[str, Any]:
+    def get_config(self, task_id: str = '') -> Dict[str, Any]:
         """construct and return kafka connection configuration"""
         config = {
             "bootstrap.servers": self.bootstrap_servers,
@@ -202,7 +203,7 @@ class KafkaConsumerPlugin(WorkflowPlugin):
             "group.id": self.group_id,
             "enable.auto.commit": True,
             "auto.offset.reset": self.auto_offset_reset,
-            "client.id": "cmem-plugin-kafka",
+            "client.id": get_client_id(client_id=self.client_id, task_id=task_id),
             "statistics.interval.ms": "250",
             "stats_cb": self.metrics_callback,
         }
@@ -222,7 +223,7 @@ class KafkaConsumerPlugin(WorkflowPlugin):
         self.message_dataset = f"{context.task.project_id()}:{self.message_dataset}"
 
         kafka_consumer = KafkaConsumer(
-            config=self.get_config(),
+            config=self.get_config(task_id=context.task.task_id()),
             topic=self.kafka_topic,
             log=self.log,
             context=context,

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -108,6 +108,7 @@ def test_execution_kafka_producer_consumer(project):
 @needs_cmem
 @needs_kafka
 def test_validate_invalid_inputs(project):
+    """Validate Invalid Inputs"""
     # Invalid Dataset
     with pytest.raises(requests.exceptions.HTTPError):
         KafkaConsumerPlugin(

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -93,6 +93,7 @@ def test_execution_kafka_producer_consumer(project):
         kafka_topic=DEFAULT_TOPIC,
         group_id=DEFAULT_GROUP,
         auto_offset_reset="earliest",
+        client_id=''
     ).execute(None, TestExecutionContext(project_id=PROJECT_NAME))
 
     # Ensure producer and consumer are working properly
@@ -121,6 +122,7 @@ def test_validate_invalid_inputs(project):
             kafka_topic=DEFAULT_TOPIC,
             group_id=DEFAULT_GROUP,
             auto_offset_reset=DEFAULT_RESET,
+            client_id=''
         ).execute(None, TestExecutionContext(project_id=PROJECT_NAME))
 
     # Invalid SECURITY PROTOCOL
@@ -135,6 +137,7 @@ def test_validate_invalid_inputs(project):
             kafka_topic=DEFAULT_TOPIC,
             group_id=DEFAULT_GROUP,
             auto_offset_reset=DEFAULT_RESET,
+            client_id=''
         ).execute(None, TestExecutionContext(project_id=PROJECT_NAME))
 
 
@@ -151,6 +154,7 @@ def test_validate_bootstrap_server():
             kafka_topic=DEFAULT_TOPIC,
             group_id=DEFAULT_GROUP,
             auto_offset_reset=DEFAULT_RESET,
+            client_id=''
         )
 
     with pytest.raises(
@@ -168,4 +172,5 @@ def test_validate_bootstrap_server():
             kafka_topic=DEFAULT_TOPIC,
             group_id=DEFAULT_GROUP,
             auto_offset_reset=DEFAULT_RESET,
+            client_id=''
         )

--- a/tests/test_perf_200K_messages.py
+++ b/tests/test_perf_200K_messages.py
@@ -98,6 +98,7 @@ def test_performance_execution_kafka_producer_consumer(perf_project):
         kafka_topic=DEFAULT_TOPIC,
         group_id=DEFAULT_GROUP,
         auto_offset_reset="earliest",
+        client_id=''
     ).execute([], TestExecutionContext(project_id=PROJECT_NAME))
 
     # Ensure producer and consumer are working properly

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -9,6 +9,7 @@ import pytest
 # check for cmem environment and skip if not present
 from _pytest.mark import MarkDecorator
 from cmem.cmempy.api import get_token
+from cmem_plugin_kafka.constants import BASE_URI
 from cmem_plugin_base.dataintegration.context import (
     ExecutionContext,
     ReportContext,
@@ -18,7 +19,7 @@ from cmem_plugin_base.dataintegration.context import (
 )
 
 needs_cmem: MarkDecorator = pytest.mark.skipif(
-    "CMEM_BASE_URI" not in os.environ, reason="Needs CMEM configuration"
+    BASE_URI not in os.environ, reason="Needs CMEM configuration"
 )
 
 needs_kafka: MarkDecorator = pytest.mark.skipif(


### PR DESCRIPTION
### Added

- `Client_Id` parameter has been added to the advanced section of Kafka Consumer.
- When the `Client_Id` field is empty, the plugin defaults to `DNS:TASK ID`.

### Changed

- The string `CMEM_BASE_URI` has been made constant. As a result, updated `@needs-cmem`.